### PR TITLE
Add PHP 8 support and Leaflet map option

### DIFF
--- a/blitzortung.php
+++ b/blitzortung.php
@@ -44,8 +44,10 @@ if (!defined("BO_VER"))
 
 
 
-	//Some default PHP-Options
-	ini_set('magic_quotes_runtime', 0);
+        //Some default PHP-Options
+        if (function_exists('ini_set')) {
+                @ini_set('magic_quotes_runtime', 0);
+        }
 
 	//Config var.
 	global $_BO, $_BL;

--- a/config.php.example
+++ b/config.php.example
@@ -39,6 +39,9 @@ define("BO_STATION_ID", "");
 //Your timezone
 define("BO_TIMEZONE", "UTC");
 
+// Map provider: gmap or leaflet
+define("BO_MAP_PROVIDER", "gmap");
+
 
 //To see error messages, enable this (set to true)
 define("BO_DEBUG", false);

--- a/includes/classes/Db.class.php
+++ b/includes/classes/Db.class.php
@@ -10,10 +10,11 @@
  * Todo: User-configurable
  */
 
-if (class_exists('mysqli'))
-	require_once 'Db/Mysqli.class.php';
-else
-	require_once 'Db/Mysql.class.php';
+if (PHP_VERSION_ID >= 70000 || class_exists('mysqli')) {
+        require_once 'Db/Mysqli.class.php';
+} else {
+        require_once 'Db/Mysql.class.php';
+}
 
 
 

--- a/includes/codebird/src/codebird.php
+++ b/includes/codebird/src/codebird.php
@@ -206,7 +206,7 @@ class Codebird
             } else {
                 parse_str($params[0], $apiparams);
                 // remove auto-added slashes if on magic quotes steroids
-                if (get_magic_quotes_gpc()) {
+                if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
                     foreach($apiparams as $key => $value) {
                         if (is_array($value)) {
                             $apiparams[$key] = array_map('stripslashes', $value);

--- a/includes/default_settings.inc.php
+++ b/includes/default_settings.inc.php
@@ -528,6 +528,8 @@
 
 //Completely disable the dynamic map
 @define('BO_MAP_DISABLE', false);
+// map provider: 'gmap' or 'leaflet'
+@define('BO_MAP_PROVIDER', 'gmap');
 
 // default zoom level
 @define('BO_DEFAULT_ZOOM', 7);
@@ -980,7 +982,7 @@
 @define('BO_GRAPH_RAW_H_STAT_SPEC', 150);
 
 
-//max. time in µs for displaying all graphs to a stroke
+//max. time in Âµs for displaying all graphs to a stroke
 @define('BO_GRAPH_RAW_MAX_TIME2', 350);
 
 //Colors
@@ -1408,7 +1410,7 @@ define('BO_LOADAVG_TILES_STATIONS', 70);
 @define('BO_TRIGGER_VOLTAGE', 0.45);
 
 //search interval for strike -> signal matching for foreign stations
-@define('BO_STR2SIG_INTERVAL_OTHERS', 8000); //µs
+@define('BO_STR2SIG_INTERVAL_OTHERS', 8000); //Âµs
 
 //needed for auto linking stations
 @define('BO_LINK_HOST', 'www.myblitzortung.org');

--- a/includes/functions_dynmap.inc.php
+++ b/includes/functions_dynmap.inc.php
@@ -15,12 +15,26 @@ function bo_insert_map($show_station=3, $lat=BO_LAT, $lon=BO_LON, $zoom=BO_DEFAU
 	$station_lat = BO_LAT;
 	$station_lon = BO_LON;
 	$center_lat = BO_MAP_LAT ? BO_MAP_LAT : BO_LAT;
-	$center_lon = BO_MAP_LON ? BO_MAP_LON : BO_LON;
-	
+        $center_lon = BO_MAP_LON ? BO_MAP_LON : BO_LON;
+
+        if (BO_MAP_PROVIDER === 'leaflet') {
+                echo "<div id=\"bo_gmap\" style=\"width:500px; height:400px;\"></div>";
+                echo '<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />';
+                echo '<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>';
+                echo '<script>';
+                echo "var bo_map = L.map('bo_gmap').setView([$lat, $lon], $zoom);";
+                echo "L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:19,attribution:'&copy; OpenStreetMap contributors'}).addTo(bo_map);";
+                if ($show_station & 1) {
+                        echo "L.marker([$station_lat,$station_lon]).addTo(bo_map).bindPopup(\""._BC($station_text)."\");";
+                }
+                echo '</script>';
+                return;
+        }
+
 ?>
 
 
-	<script type="text/javascript" id="bo_script_map">
+        <script type="text/javascript" id="bo_script_map">
 	
 	
 <?php if ($poverlay) { ?>

--- a/install/index.php
+++ b/install/index.php
@@ -3,7 +3,9 @@
 
 error_reporting(E_ALL & ~E_NOTICE);
 ini_set('display_errors', 1);
-ini_set('magic_quotes_runtime', 0); 
+if (function_exists('ini_set')) {
+    @ini_set('magic_quotes_runtime', 0);
+}
 
 $path = realpath(dirname(__FILE__).'/../').'/';
 


### PR DESCRIPTION
## Summary
- avoid removed function `get_magic_quotes_gpc`
- support mysqli when running PHP 7+
- add configurable map provider and basic Leaflet support
- disable deprecated `magic_quotes_runtime`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff7ae0c0c8326b39e960d3fdea129