### PR TITLE
Fix GIFEncoder for PHP 8

### DIFF
--- a/includes/gifencoder/GIFEncoder.class.php
+++ b/includes/gifencoder/GIFEncoder.class.php
@@ -2,7 +2,7 @@
 /*
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::
-::	GIFEncoder Version 2.0 by László Zsidi, http://gifs.hu
+::	GIFEncoder Version 2.0 by LÃ¡szlÃ³ Zsidi, http://gifs.hu
 ::
 ::	This class is a rewritten 'GifMerge.class.php' version.
 ::
@@ -76,8 +76,8 @@ Class GIFEncoder {
 				printf	( "%s: %d %s", $this->VER, $i, $this->ERR [ 'ERR01' ] );
 				exit	( 0 );
 			}
-			for ( $j = ( 13 + 3 * ( 2 << ( ord ( $this->BUF [ $i ] { 10 } ) & 0x07 ) ) ), $k = TRUE; $k; $j++ ) {
-				switch ( $this->BUF [ $i ] { $j } ) {
+			for ( $j = ( 13 + 3 * ( 2 << ( ord ( $this->BUF [ $i ] [10] ) & 0x07 ) ) ), $k = TRUE; $k; $j++ ) {
+				switch ( $this->BUF [ $i ] [$j] ) {
 					case "!":
 						if ( ( substr ( $this->BUF [ $i ], ( $j + 3 ), 8 ) ) == "NETSCAPE" ) {
 							printf	( "%s: %s ( %s source )!", $this->VER, $this->ERR [ 'ERR03' ], ( $i + 1 ) );
@@ -105,8 +105,8 @@ Class GIFEncoder {
 	function GIFAddHeader ( ) {
 		$cmap = 0;
 
-		if ( ord ( $this->BUF [ 0 ] { 10 } ) & 0x80 ) {
-			$cmap = 3 * ( 2 << ( ord ( $this->BUF [ 0 ] { 10 } ) & 0x07 ) );
+		if ( ord ( $this->BUF [0][10] ) & 0x80 ) {
+			$cmap = 3 * ( 2 << ( ord ( $this->BUF [0][10] ) & 0x07 ) );
 
 			$this->GIF .= substr ( $this->BUF [ 0 ], 6, 7		);
 			$this->GIF .= substr ( $this->BUF [ 0 ], 13, $cmap	);
@@ -121,28 +121,28 @@ Class GIFEncoder {
 	*/
 	function GIFAddFrames ( $i, $d ) {
 
-		$Locals_str = 13 + 3 * ( 2 << ( ord ( $this->BUF [ $i ] { 10 } ) & 0x07 ) );
+		$Locals_str = 13 + 3 * ( 2 << ( ord ( $this->BUF [ $i ] [10] ) & 0x07 ) );
 
 		$Locals_end = strlen ( $this->BUF [ $i ] ) - $Locals_str - 1;
 		$Locals_tmp = substr ( $this->BUF [ $i ], $Locals_str, $Locals_end );
 
-		$Global_len = 2 << ( ord ( $this->BUF [ 0  ] { 10 } ) & 0x07 );
-		$Locals_len = 2 << ( ord ( $this->BUF [ $i ] { 10 } ) & 0x07 );
+		$Global_len = 2 << ( ord ( $this->BUF [ 0  ] [10] ) & 0x07 );
+		$Locals_len = 2 << ( ord ( $this->BUF [ $i ] [10] ) & 0x07 );
 
 		$Global_rgb = substr ( $this->BUF [ 0  ], 13,
-							3 * ( 2 << ( ord ( $this->BUF [ 0  ] { 10 } ) & 0x07 ) ) );
+							3 * ( 2 << ( ord ( $this->BUF [ 0  ] [10] ) & 0x07 ) ) );
 		$Locals_rgb = substr ( $this->BUF [ $i ], 13,
-							3 * ( 2 << ( ord ( $this->BUF [ $i ] { 10 } ) & 0x07 ) ) );
+							3 * ( 2 << ( ord ( $this->BUF [ $i ] [10] ) & 0x07 ) ) );
 
 		$Locals_ext = "!\xF9\x04" . chr ( ( $this->DIS << 2 ) + 0 ) .
 						chr ( ( $d >> 0 ) & 0xFF ) . chr ( ( $d >> 8 ) & 0xFF ) . "\x0\x0";
 
-		if ( $this->COL > -1 && ord ( $this->BUF [ $i ] { 10 } ) & 0x80 ) {
-			for ( $j = 0; $j < ( 2 << ( ord ( $this->BUF [ $i ] { 10 } ) & 0x07 ) ); $j++ ) {
+		if ( $this->COL > -1 && ord ( $this->BUF [ $i ] [10] ) & 0x80 ) {
+			for ( $j = 0; $j < ( 2 << ( ord ( $this->BUF [ $i ] [10] ) & 0x07 ) ); $j++ ) {
 				if	(
-						ord ( $Locals_rgb { 3 * $j + 0 } ) == ( ( $this->COL >> 16 ) & 0xFF ) &&
-						ord ( $Locals_rgb { 3 * $j + 1 } ) == ( ( $this->COL >>  8 ) & 0xFF ) &&
-						ord ( $Locals_rgb { 3 * $j + 2 } ) == ( ( $this->COL >>  0 ) & 0xFF )
+						ord ( $Locals_rgb[3 * $j + 0] ) == ( ( $this->COL >> 16 ) & 0xFF ) &&
+						ord ( $Locals_rgb[3 * $j + 1] ) == ( ( $this->COL >>  8 ) & 0xFF ) &&
+						ord ( $Locals_rgb[3 * $j + 2] ) == ( ( $this->COL >>  0 ) & 0xFF )
 					) {
 					$Locals_ext = "!\xF9\x04" . chr ( ( $this->DIS << 2 ) + 1 ) .
 									chr ( ( $d >> 0 ) & 0xFF ) . chr ( ( $d >> 8 ) & 0xFF ) . chr ( $j ) . "\x0";
@@ -150,7 +150,7 @@ Class GIFEncoder {
 				}
 			}
 		}
-		switch ( $Locals_tmp { 0 } ) {
+		switch ( $Locals_tmp [0] ) {
 			case "!":
 				$Locals_img = substr ( $Locals_tmp, 8, 10 );
 				$Locals_tmp = substr ( $Locals_tmp, 18, strlen ( $Locals_tmp ) - 18 );
@@ -160,26 +160,26 @@ Class GIFEncoder {
 				$Locals_tmp = substr ( $Locals_tmp, 10, strlen ( $Locals_tmp ) - 10 );
 				break;
 		}
-		if ( ord ( $this->BUF [ $i ] { 10 } ) & 0x80 && $this->IMG > -1 ) {
+		if ( ord ( $this->BUF [ $i ] [10] ) & 0x80 && $this->IMG > -1 ) {
 			if ( $Global_len == $Locals_len ) {
 				if ( GIFEncoder::GIFBlockCompare ( $Global_rgb, $Locals_rgb, $Global_len ) ) {
 					$this->GIF .= ( $Locals_ext . $Locals_img . $Locals_tmp );
 				}
 				else {
-					$byte  = ord ( $Locals_img { 9 } );
+					$byte  = ord ( $Locals_img [9] );
 					$byte |= 0x80;
 					$byte &= 0xF8;
-					$byte |= ( ord ( $this->BUF [ 0 ] { 10 } ) & 0x07 );
-					$Locals_img { 9 } = chr ( $byte );
+					$byte |= ( ord ( $this->BUF [0][10] ) & 0x07 );
+					$Locals_img [9] = chr ( $byte );
 					$this->GIF .= ( $Locals_ext . $Locals_img . $Locals_rgb . $Locals_tmp );
 				}
 			}
 			else {
-				$byte  = ord ( $Locals_img { 9 } );
+				$byte  = ord ( $Locals_img [9] );
 				$byte |= 0x80;
 				$byte &= 0xF8;
-				$byte |= ( ord ( $this->BUF [ $i ] { 10 } ) & 0x07 );
-				$Locals_img { 9 } = chr ( $byte );
+				$byte |= ( ord ( $this->BUF [ $i ] [10] ) & 0x07 );
+				$Locals_img [9] = chr ( $byte );
 				$this->GIF .= ( $Locals_ext . $Locals_img . $Locals_rgb . $Locals_tmp );
 			}
 		}
@@ -207,9 +207,9 @@ Class GIFEncoder {
 
 		for ( $i = 0; $i < $Len; $i++ ) {
 			if	(
-					$GlobalBlock { 3 * $i + 0 } != $LocalBlock { 3 * $i + 0 } ||
-					$GlobalBlock { 3 * $i + 1 } != $LocalBlock { 3 * $i + 1 } ||
-					$GlobalBlock { 3 * $i + 2 } != $LocalBlock { 3 * $i + 2 }
+					$GlobalBlock[3 * $i + 0] != $LocalBlock[3 * $i + 0] ||
+					$GlobalBlock[3 * $i + 1] != $LocalBlock[3 * $i + 1] ||
+					$GlobalBlock[3 * $i + 2] != $LocalBlock[3 * $i + 2]
 				) {
 					return ( 0 );
 			}


### PR DESCRIPTION
## Summary
- modernize `includes/gifencoder/GIFEncoder.class.php` to remove deprecated curly brace array access so that PHP 8 syntax checks pass

## Testing
- `php -l includes/gifencoder/GIFEncoder.class.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_683ffa2a09308326a528639557d66d5c