### PR TITLE
Fix default map provider

### DIFF
--- a/includes/default_settings.inc.php
+++ b/includes/default_settings.inc.php
@@ -529,7 +529,10 @@
 //Completely disable the dynamic map
 @define('BO_MAP_DISABLE', false);
 // map provider: 'gmap' or 'leaflet'
-@define('BO_MAP_PROVIDER', 'gmap');
+// Using Google Maps without an API key no longer works reliably. Switching the
+// default provider to the open source Leaflet library ensures the map is
+// displayed without additional configuration.
+@define('BO_MAP_PROVIDER', 'leaflet');
 
 // default zoom level
 @define('BO_DEFAULT_ZOOM', 7);


### PR DESCRIPTION
## Summary
- use Leaflet as the default map provider so the map works without a Google API key

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840437801d4832698489a3345cd64d0