### PR TITLE
Fix constant definition to prevent fatal error

### DIFF
--- a/includes/user.inc.php
+++ b/includes/user.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 //workaround for myblitzortung.ORG
-@define(BO_DB_PREF_USER, BO_DB_PREF);
+@define('BO_DB_PREF_USER', BO_DB_PREF);
 
 
 function bo_user_show_admin()


### PR DESCRIPTION
## Summary
- correctly define `BO_DB_PREF_USER` constant

## Testing
- `php -l includes/user.inc.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68404f153e4083268d662a9d3fcbab67