### PR TITLE
Switch to Leaflet map provider

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -40,7 +40,9 @@ define("BO_STATION_ID", "");
 define("BO_TIMEZONE", "UTC");
 
 // Map provider: gmap or leaflet
-define("BO_MAP_PROVIDER", "gmap");
+// Google Maps now requires an API key. Leaflet works without one and
+// is the recommended default.
+define("BO_MAP_PROVIDER", "leaflet");
 
 
 //To see error messages, enable this (set to true)

--- a/includes/default_settings.inc.php
+++ b/includes/default_settings.inc.php
@@ -529,11 +529,7 @@
 //Completely disable the dynamic map
 @define('BO_MAP_DISABLE', false);
 
-// Map provider: use 'gmap' (Google Maps) or 'leaflet'. The codebase expects
-// Google Maps for most dynamic features, so keep it as default.
-@define('BO_MAP_PROVIDER', 'gmap');
-
-// map provider: 'gmap' or 'leaflet'
+// Map provider: use 'gmap' (Google Maps) or 'leaflet'.
 // Using Google Maps without an API key no longer works reliably. Switching the
 // default provider to the open source Leaflet library ensures the map is
 // displayed without additional configuration.


### PR DESCRIPTION
## Summary
- use Leaflet as default map provider for better out-of-box experience
- update example configuration accordingly

## Testing
- `php -l includes/default_settings.inc.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404fd609f88326847cb1c5ea2c4ff9